### PR TITLE
fixing broken path

### DIFF
--- a/client/src/pages/speakers/index.tsx
+++ b/client/src/pages/speakers/index.tsx
@@ -44,7 +44,7 @@ export default function Speakers() {
             >
               Register for Free
             </a>
-            <Link className={styles.archiveLink} to="/archive/speakers2025">
+            <Link className={styles.archiveLink} to="/conf#archive">
               View 2025 Speakers →
             </Link>
           </div>


### PR DESCRIPTION

This pull request makes a small update to the navigation link for viewing archived speakers. The link now directs users to the conference archive section instead of a specific archive page.

* Changed the "View 2025 Speakers" link in `client/src/pages/speakers/index.tsx` to point to `/conf#archive` instead of `/archive/speakers2025`.