### PR TITLE
updating with news and discord

### DIFF
--- a/client/docusaurus.config.ts
+++ b/client/docusaurus.config.ts
@@ -231,7 +231,7 @@ const config: Config = {
             },
             {
               label: 'Discord',
-              href: 'https://discord.gg/yKnQqWgg',
+              href: 'https://discord.gg/pczdC2SU',
             },
             {
               label: 'X',

--- a/client/src/pages/conf/ConfFooter.tsx
+++ b/client/src/pages/conf/ConfFooter.tsx
@@ -124,7 +124,7 @@ export default function ConfFooter({ confYear = "2026" }: ConfFooterProps) {
               </a>
               <a
                 className={styles.confFooterLink}
-                href="https://discord.gg/yKnQqWgg"
+                href="https://discord.gg/pczdC2SU"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/client/src/pages/conf/news.json
+++ b/client/src/pages/conf/news.json
@@ -1,5 +1,11 @@
 [
   {
+    "title": "The Countdown to Azure Cosmos DB Conf 2026 Starts Now",
+    "date": "March 11, 2026",
+    "content": "April 28 is coming fast. We've published a full preview of what to expect — from cutting-edge AI agent architectures to production-hardened data modeling and everything in between. <a href='https://devblogs.microsoft.com/cosmosdb/azure-cosmos-db-conf-2026-preview/' target='_blank' rel='noopener noreferrer'>Read the preview</a>. Also, want in on the action early? The <strong>#nosql</strong> channel on the <a href='https://discord.com/invite/pczdC2SU' target='_blank' rel='noopener noreferrer'>Azure Open Source Discord</a> is live — connect with the community, talk sessions, and get hyped with us.",
+    "event_date": "April 28, 2026"
+  },
+  {
     "title": "Meet the Speakers for Azure Cosmos DB Conf 2026!",
     "date": "March 4, 2026",
     "content": "We're proud to announce our speaker lineup for Azure Cosmos DB Conf 2026, presented in partnership with <strong>AMD</strong>! Thanks to AMD's support, we've expanded the show to a full 5 hours — 9:00 AM to 2:00 PM PST. This year's roster brings together world-class speakers from across the community — covering AI and RAG architectures, vector search, MCP servers, security, data modeling, distributed systems, and more. <a href='#speakers'>Meet the speakers</a> and see who's joining us on April 28, 2026.",


### PR DESCRIPTION
This pull request updates the Discord invite link throughout the site and adds a new news item for the upcoming Azure Cosmos DB Conf 2026. The most important changes are:

**Discord Link Update:**

* Updated the Discord invite URL from `https://discord.gg/yKnQqWgg` to `https://discord.gg/pczdC2SU` in both the Docusaurus site configuration (`docusaurus.config.ts`) and the conference footer component (`ConfFooter.tsx`). [[1]](diffhunk://#diff-df486239f2a1bec6d726f788de76d67c0753410d8c8d5cf6c447273954fd665eL234-R234) [[2]](diffhunk://#diff-c43ca48476a966a79ef1d9dbb0237cae6a8e14de63d0884e3f9324f6a89ef64bL127-R127)

**Conference News:**

* Added a new entry to `news.json` announcing the countdown to Azure Cosmos DB Conf 2026, including links to the event preview and the updated Discord channel.