### PR TITLE
go-live

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -274,3 +274,5 @@ youtube-session-descriptions.md
 agenda-live.md
 agenda-live.svg
 agenda-live.png
+agenda-social-posts.md
+welcome-to-cosmos-conf-2026.md

--- a/client/src/pages/conf/index.tsx
+++ b/client/src/pages/conf/index.tsx
@@ -242,8 +242,12 @@ const ConfPage = () => {
           </div>
         </header>
 
-        {showStream && streamLive && (
-          <StreamSection confYear={CONF_YEAR} streamEmbedUrl={streamEmbedUrl} live />
+        {showStream && (
+          <StreamSection
+            confYear={CONF_YEAR}
+            streamEmbedUrl={streamEmbedUrl}
+            live={streamLive}
+          />
         )}
 
         <section className={styles.introSection} aria-labelledby="conf-intro">
@@ -361,8 +365,6 @@ const ConfPage = () => {
             </div>
           </div>
         </section>
-
-        {showStream && !streamLive && <StreamSection confYear={CONF_YEAR} streamEmbedUrl={streamEmbedUrl} />}
 
         <NewsSection confYear={CONF_YEAR} />
 


### PR DESCRIPTION
This pull request simplifies the logic for rendering the `StreamSection` component on the conference page. Instead of conditionally rendering separate `StreamSection` components based on the stream's live status, the code now always renders a single `StreamSection` when `showStream` is true and passes the live status as a prop.

Component rendering simplification:

* Updated the `ConfPage` component in `client/src/pages/conf/index.tsx` to always render a single `StreamSection` when `showStream` is true, passing the `live` prop based on the `streamLive` variable. This replaces the previous logic that conditionally rendered different `StreamSection` components depending on whether the stream was live. [[1]](diffhunk://#diff-cf64a3c58f105fbff60cda12ccf58887ace9fb0292dab39ef8bd916708296884L245-R250) [[2]](diffhunk://#diff-cf64a3c58f105fbff60cda12ccf58887ace9fb0292dab39ef8bd916708296884L365-L366)