### PR TITLE
updated with new videos and news item

### DIFF
--- a/client/src/conf/videoRelease.ts
+++ b/client/src/conf/videoRelease.ts
@@ -39,17 +39,19 @@ const { live, onDemand } = agendaData as {
 const allSessions: AgendaEntry[] = [...live, ...onDemand];
 
 /**
- * Look up a YouTube URL for a given speaker slug. Returns the first matching
- * session URL, or undefined if the speaker has no URL (yet).
+ * Look up a YouTube URL for a given speaker slug. Prefers sessions where the
+ * speaker is the sole speaker (their own talk) over multi-speaker sessions
+ * like the keynote panel. Falls back to the first multi-speaker match.
  */
 export const getVideoUrlForSpeaker = (slug: string): string | undefined => {
+  let fallback: string | undefined;
   for (const session of allSessions) {
     if (!session.url) continue;
-    if (session.speakers.some((s) => s.slug === slug)) {
-      return session.url;
-    }
+    if (!session.speakers.some((s) => s.slug === slug)) continue;
+    if (session.speakers.length === 1) return session.url;
+    if (!fallback) fallback = session.url;
   }
-  return undefined;
+  return fallback;
 };
 
 /**

--- a/client/src/pages/conf/agenda.json
+++ b/client/src/pages/conf/agenda.json
@@ -11,7 +11,7 @@
         { "name": "Andrew Liu", "slug": "andrew-liu" },
         { "name": "Steve Berg", "slug": "steve-berg" }
       ],
-      "url": ""
+      "url": "https://youtu.be/lOppojg4QlY"
     },
     {
       "time": "9:48 AM",
@@ -95,7 +95,7 @@
       "title": "Behind the Scenes: How Azure Cosmos DB Runs Under the Hood",
       "description": "A whiteboard walkthrough of Azure Cosmos DB's internals — replica sets, consistent hashing, Request Units, and RU pooling across a global fleet.",
       "speakers": [{ "name": "Andrew Liu", "slug": "andrew-liu" }],
-      "url": "https://youtu.be/6POmAm--Kgk"
+      "url": "https://youtu.be/A7Q_wZqUmJc"
     },
     {
       "time": "1:30 PM",
@@ -117,6 +117,12 @@
       "description": "Jonathan Lee from OpenAI's online storage team joins Kirill Gavrylyuk on what it takes for a database to keep up with OpenAI.",
       "speakers": [{ "name": "Jonathan Lee", "slug": "jonathan-lee" }],
       "url": "https://youtu.be/CU10bYYjqPA"
+    },
+    {
+      "title": "Keynote Interview: AMD's Steve Berg on the Hardware Behind Cosmos DB",
+      "description": "Steve Berg, CVP & GM Server CPU Cloud at AMD, joins Kirill Gavrylyuk on the AMD EPYC silicon powering Azure Cosmos DB across the globe.",
+      "speakers": [{ "name": "Steve Berg", "slug": "steve-berg" }],
+      "url": "https://youtu.be/eL-Wj27FHmM"
     },
     {
       "title": "Distributed Locks, Sagas, and Coordination with Cosmos DB",

--- a/client/src/pages/conf/news.json
+++ b/client/src/pages/conf/news.json
@@ -1,5 +1,11 @@
 [
   {
+    "title": "Still Open — Skills Challenge Runs Through May 8",
+    "date": "May 1, 2026",
+    "content": "<p class='keynote-intro'>Missed it during the conference? <strong>You still have time.</strong> The <strong>Azure Cosmos DB Conf 2026 Cloud Skills Challenge</strong> is open through <strong>May 8, 2026</strong> — complete the modules and submit your entry to qualify for a <strong>100% discount</strong> on a DP-420 certification exam voucher (one of 500 available).</p><p class='keynote-cta'><a class='keynote-cta-button' href='https://aka.ms/CosmosDBConfChallenge' target='_blank' rel='noopener noreferrer'>Start the Skills Challenge</a></p><p class='keynote-cta' style='font-size:13px;opacity:0.75;margin-top:10px;'><a href='https://aka.ms/CosmosDBSkillsChallengeSweepstakesEntry' target='_blank' rel='noopener noreferrer'>Submit sweepstakes entry</a> by May 8, 2026</p>",
+    "event_date": "May 8, 2026"
+  },
+  {
     "title": "That's a Wrap — Thank You, Cosmos Conf 2026!",
     "date": "April 28, 2026",
     "content": "<p class='keynote-intro'>And just like that, <strong>Azure Cosmos DB Conf 2026</strong> is in the books. A huge <strong>thank you</strong> to everyone who tuned in today — and to the <strong>incredible speakers</strong>, the production crew, and the partners who made the show happen.</p><p class='keynote-intro'>A special shout-out to our <strong>community</strong> who showed up in the YouTube live chat and kept the energy going all day long. You make this event what it is.</p><p class='keynote-intro'>Missed something? <strong>Every session is now available on demand.</strong> Browse the <a class='blue' href='#speakers'>speaker cards</a> to find each session embedded next to its speaker, or watch the full <strong>Cosmos Conf 2026 playlist</strong> on YouTube.</p><p class='keynote-cta'><a class='keynote-cta-button' href='https://aka.ms/CosmosConf26Playlist' target='_blank' rel='noopener noreferrer'>Watch the Full Playlist on YouTube</a></p><p class='keynote-cta' style='font-size:13px;opacity:0.75;margin-top:10px;'><a href='#speakers'>Browse speakers &amp; sessions</a> · <a href='https://aka.ms/CosmosConf2026Survey' target='_blank' rel='noopener noreferrer'>Share your feedback</a></p>",

--- a/client/src/pages/conf/speakers2026.json
+++ b/client/src/pages/conf/speakers2026.json
@@ -43,8 +43,8 @@
     "website": "",
     "bio": "Strategic and results-driven Business Development Executive with more than 29 years of international experience in the cloud computing infrastructure and semiconductor industries. Leads platform enablement for AMD hyperscale accounts, formerly ZT Systems. Lead strategic business planning, marketing, ecosystem, and portfolio development for Flex's Communications, Enterprise, and Cloud segments. Lead and managed all aspects of Intel's global cloud computing business, including top account management, sales, marketing, and product line management. Lead factory process and production engineering, manufacturing, and process control.",
     "session": {
-      "title": "Keynote Featured Guest",
-      "abstract": "Steve Berg from AMD joins the Azure Cosmos DB Conf 2026 keynote conversation on modern applications, AI, and data at scale."
+      "title": "Keynote Interview: AMD on the Hardware Behind Cosmos DB",
+      "abstract": "Steve Berg, Corporate Vice President & GM, Server CPU Cloud at AMD, joins Kirill Gavrylyuk for a keynote conversation about the silicon quietly powering one of the world's largest distributed databases. They cover nearly a decade of AMD EPYC in the Azure cloud, how EPYC powers Azure Cosmos DB across datacenters worldwide, the impact of 3D V-Cache and higher core counts on database workloads, and how AMD ↔ Microsoft co-engineering feeds Cosmos DB features like autoscale, RU pooling, and serverless — all in service of better performance per dollar per watt."
     }
   },
   {


### PR DESCRIPTION
This pull request updates conference agenda data, video URLs, and speaker/session details, as well as adds a new news item about the Skills Challenge. The main focus is on improving how speaker video URLs are selected, updating session metadata, and ensuring accurate, up-to-date information for attendees.

**Agenda and video updates:**

* Improved the `getVideoUrlForSpeaker` function in `videoRelease.ts` to prefer sessions where the speaker is the sole presenter, falling back to multi-speaker sessions only if necessary. This ensures that links for speakers point to their main talk when available.
* Updated session video URLs in `agenda.json`:
  - Added a YouTube URL for the "Andrew Liu, Steve Berg" session.
  - Changed the video URL for "Behind the Scenes: How Azure Cosmos DB Runs Under the Hood" to a new YouTube link.
  - Added a new session: "Keynote Interview: AMD's Steve Berg on the Hardware Behind Cosmos DB," including its YouTube URL.

**Speaker/session metadata:**

* Updated Steve Berg's session title and abstract in `speakers2026.json` to reflect the new keynote interview, providing a more detailed and accurate session description.

**News and announcements:**

* Added a new news item in `news.json` about the Skills Challenge, highlighting its extension through May 8, 2026, and details on how to participate and submit entries.