### PR TITLE
wrapping up changes for 2026 until CSC ends

### DIFF
--- a/client/docusaurus.config.ts
+++ b/client/docusaurus.config.ts
@@ -24,7 +24,10 @@ const config: Config = {
   tagline: 'Infinite Scale, Instant Impact!',
   favicon: 'img/favicon.ico',
 
-  clientModules: ['./src/clientModules/confMobileHashActive.ts'],
+  clientModules: [
+    './src/clientModules/confMobileHashActive.ts',
+    './src/clientModules/clientErrorLogger.ts',
+  ],
 
   url: 'https://developer.azurecosmosdb.com',
   baseUrl: '/',

--- a/client/src/clientModules/clientErrorLogger.ts
+++ b/client/src/clientModules/clientErrorLogger.ts
@@ -1,33 +1,274 @@
+/**
+ * Client-side error + performance logger.
+ *
+ * Captures runtime errors, unhandled promise rejections, failed resource
+ * loads, slow long-tasks, and a few page-load timings. Persists the most
+ * recent events to localStorage (capped) so you can pull them back after a
+ * page crash or slowdown.
+ *
+ * Logs are NOT shipped anywhere — they live only in the browser. To inspect
+ * them:
+ *
+ *   1. Open DevTools console (errors print there in real time, prefixed
+ *      `[client-error]` / `[client-perf]`).
+ *   2. Run `window.__getClientLog()` — returns the current buffer as an
+ *      array.
+ *   3. Run `window.__downloadClientLog()` — downloads the buffer as a
+ *      JSON file you can attach to a bug report. Or visit any URL on the
+ *      site with `?downloadClientLog` to trigger the download
+ *      automatically.
+ *   4. Run `window.__clearClientLog()` to reset the buffer.
+ *
+ * Nothing here is committed to git: logs only live in localStorage / Blob
+ * downloads, and the *.log gitignore at repo root blocks any local files
+ * you save from the download dialog.
+ */
+
+interface LogEntry {
+  ts: string;
+  kind:
+    | "error"
+    | "unhandledrejection"
+    | "resource-error"
+    | "long-task"
+    | "navigation"
+    | "console-error"
+    | "console-warn";
+  href: string;
+  details: Record<string, unknown>;
+}
+
+const LOG_KEY = "__cosmosconf_client_log__";
+const MAX_ENTRIES = 200;
+const LONG_TASK_THRESHOLD_MS = 200;
+
+function safeStringify(value: unknown): string {
+  if (value instanceof Error) {
+    return `${value.name}: ${value.message}\n${value.stack ?? ""}`;
+  }
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
 function runWhenBrowser(fn: () => void): void {
   if (typeof window === "undefined" || typeof document === "undefined") return;
   fn();
 }
 
 runWhenBrowser(() => {
-  const logPrefix = "[client-error]";
+  const w = window as unknown as {
+    __getClientLog?: () => LogEntry[];
+    __clearClientLog?: () => void;
+    __downloadClientLog?: () => void;
+  };
 
-  window.addEventListener("error", (event) => {
-    const errorEvent = event as ErrorEvent;
-    const details = {
-      message: errorEvent.message,
-      filename: errorEvent.filename,
-      lineno: errorEvent.lineno,
-      colno: errorEvent.colno,
-      stack: errorEvent.error?.stack,
+  const readBuffer = (): LogEntry[] => {
+    try {
+      const raw = window.localStorage.getItem(LOG_KEY);
+      if (!raw) return [];
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? (parsed as LogEntry[]) : [];
+    } catch {
+      return [];
+    }
+  };
+
+  const writeBuffer = (entries: LogEntry[]): void => {
+    try {
+      window.localStorage.setItem(LOG_KEY, JSON.stringify(entries));
+    } catch {
+      // Quota or privacy mode — ignore.
+    }
+  };
+
+  const push = (entry: Omit<LogEntry, "ts" | "href">): void => {
+    const full: LogEntry = {
+      ts: new Date().toISOString(),
       href: window.location.href,
-      userAgent: navigator.userAgent,
+      ...entry,
     };
-    console.error(logPrefix, "window.error", details);
-  });
+    const buffer = readBuffer();
+    buffer.push(full);
+    if (buffer.length > MAX_ENTRIES) buffer.splice(0, buffer.length - MAX_ENTRIES);
+    writeBuffer(buffer);
+  };
 
+  // Uncaught runtime errors + failed resource loads (capture phase needed
+  // for resource errors since they don't bubble).
+  window.addEventListener(
+    "error",
+    (event) => {
+      const target = event.target as
+        | (HTMLElement & { src?: string; href?: string })
+        | null;
+      const isResourceError =
+        !!target &&
+        target !== (window as unknown as EventTarget) &&
+        (target.tagName === "IMG" ||
+          target.tagName === "SCRIPT" ||
+          target.tagName === "LINK" ||
+          target.tagName === "VIDEO" ||
+          target.tagName === "AUDIO" ||
+          target.tagName === "SOURCE");
+
+      if (isResourceError) {
+        const details = {
+          tag: target!.tagName,
+          url: target!.src || target!.href,
+          userAgent: navigator.userAgent,
+        };
+        // eslint-disable-next-line no-console
+        console.error("[client-error]", "resource-error", details);
+        push({ kind: "resource-error", details });
+        return;
+      }
+
+      const errorEvent = event as ErrorEvent;
+      const details = {
+        message: errorEvent.message,
+        filename: errorEvent.filename,
+        lineno: errorEvent.lineno,
+        colno: errorEvent.colno,
+        stack: errorEvent.error?.stack,
+        userAgent: navigator.userAgent,
+      };
+      // eslint-disable-next-line no-console
+      console.error("[client-error]", "window.error", details);
+      push({ kind: "error", details });
+    },
+    true
+  );
+
+  // Unhandled promise rejections.
   window.addEventListener("unhandledrejection", (event) => {
     const reason = event.reason as Error | string | undefined;
     const details = {
       reason: typeof reason === "string" ? reason : reason?.message,
       stack: typeof reason === "string" ? undefined : reason?.stack,
-      href: window.location.href,
       userAgent: navigator.userAgent,
     };
-    console.error(logPrefix, "unhandledrejection", details);
+    // eslint-disable-next-line no-console
+    console.error("[client-error]", "unhandledrejection", details);
+    push({ kind: "unhandledrejection", details });
   });
+
+  // Wrap console.error / console.warn so React hydration mismatches and
+  // Docusaurus runtime warnings get persisted, not just printed.
+  const origError = console.error.bind(console);
+  console.error = (...args: unknown[]) => {
+    try {
+      const first = args[0];
+      // Avoid recursion on our own logs.
+      if (!(typeof first === "string" && first.startsWith("[client-"))) {
+        push({
+          kind: "console-error",
+          details: { args: args.map(safeStringify) },
+        });
+      }
+    } catch {
+      // ignore
+    }
+    origError(...args);
+  };
+
+  const origWarn = console.warn.bind(console);
+  console.warn = (...args: unknown[]) => {
+    try {
+      const first = args[0];
+      if (!(typeof first === "string" && first.startsWith("[client-"))) {
+        push({
+          kind: "console-warn",
+          details: { args: args.map(safeStringify) },
+        });
+      }
+    } catch {
+      // ignore
+    }
+    origWarn(...args);
+  };
+
+  // Long-task observer — anything that blocks the main thread above the
+  // threshold is a likely cause of perceived slowness.
+  if (typeof PerformanceObserver !== "undefined") {
+    try {
+      const longTaskObserver = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          if (entry.duration < LONG_TASK_THRESHOLD_MS) continue;
+          const details = {
+            duration: Math.round(entry.duration),
+            startTime: Math.round(entry.startTime),
+            name: entry.name,
+            entryType: entry.entryType,
+          };
+          // eslint-disable-next-line no-console
+          console.warn("[client-perf]", "long-task", details);
+          push({ kind: "long-task", details });
+        }
+      });
+      longTaskObserver.observe({ type: "longtask", buffered: true });
+    } catch {
+      // longtask not supported in this browser — non-fatal.
+    }
+
+    try {
+      const navObserver = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries() as PerformanceNavigationTiming[]) {
+          const details = {
+            type: entry.type,
+            duration: Math.round(entry.duration),
+            domContentLoaded: Math.round(
+              entry.domContentLoadedEventEnd - entry.startTime
+            ),
+            loadEvent: Math.round(entry.loadEventEnd - entry.startTime),
+            transferSize: entry.transferSize,
+          };
+          push({ kind: "navigation", details });
+        }
+      });
+      navObserver.observe({ type: "navigation", buffered: true });
+    } catch {
+      // ignore
+    }
+  }
+
+  // Helpers exposed on window.
+  w.__getClientLog = () => readBuffer();
+  w.__clearClientLog = () => writeBuffer([]);
+  w.__downloadClientLog = () => {
+    const data = readBuffer();
+    const blob = new Blob([JSON.stringify(data, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `cosmosconf-client-log-${new Date()
+      .toISOString()
+      .replace(/[:.]/g, "-")}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  // `?downloadClientLog` query param triggers an automatic download.
+  try {
+    const params = new URLSearchParams(window.location.search);
+    if (params.has("downloadClientLog")) {
+      window.setTimeout(() => w.__downloadClientLog?.(), 1000);
+    }
+  } catch {
+    // ignore
+  }
+
+  // One-line breadcrumb so you know the logger is alive.
+  // eslint-disable-next-line no-console
+  console.info(
+    "[client-perf]",
+    "logger ready — window.__getClientLog() / __downloadClientLog() / __clearClientLog()"
+  );
 });

--- a/client/src/conf/videoRelease.ts
+++ b/client/src/conf/videoRelease.ts
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import agendaData from "../pages/conf/agenda.json";
 
 // Videos become clickable on 2026-04-28 1:30 PM PDT (PDT = UTC-7 → 20:30 UTC).
@@ -55,43 +54,15 @@ export const getVideoUrlForSpeaker = (slug: string): string | undefined => {
 };
 
 /**
- * Returns true once the shared release time has passed. The value is `false`
- * during SSR/initial render to avoid hydration mismatch, then flips to `true`
- * on the client if applicable. Re-checked every minute.
- *
- * Supports `?releaseNow` or `?streamNow` (case-insensitive, value optional;
- * `0`/`false` opts out) to force-release for testing/previewing.
+ * Post-event: time-based gating is suspended. Both hooks now always return
+ * `true` so the site is permanently in its post-event state (videos clickable,
+ * stream section shows the thank-you / recording card, no countdown, no
+ * "We're live" indicator). The timestamp constants and `hasPreviewParam`
+ * helper are kept in case time-gating needs to be re-enabled for a future
+ * event.
  */
-export const useVideoReleased = (): boolean => {
-  const [released, setReleased] = useState(false);
-  useEffect(() => {
-    const forceReleased = hasPreviewParam(["releaseNow", "streamNow"]);
-    const check = () =>
-      setReleased(forceReleased || Date.now() >= VIDEO_RELEASE_TIMESTAMP);
-    check();
-    const interval = window.setInterval(check, 60_000);
-    return () => window.clearInterval(interval);
-  }, []);
-  return released;
-};
-
-/**
- * Returns true once the live stream release time has passed. SSR-safe.
- * Supports `?streamNow` or `?releaseNow` (case-insensitive, value optional;
- * `0`/`false` opts out) for preview.
- */
-export const useStreamReleased = (): boolean => {
-  const [released, setReleased] = useState(false);
-  useEffect(() => {
-    const forceReleased = hasPreviewParam(["streamNow", "releaseNow"]);
-    const check = () =>
-      setReleased(forceReleased || Date.now() >= STREAM_RELEASE_TIMESTAMP);
-    check();
-    const interval = window.setInterval(check, 60_000);
-    return () => window.clearInterval(interval);
-  }, []);
-  return released;
-};
+export const useVideoReleased = (): boolean => true;
+export const useStreamReleased = (): boolean => true;
 
 /**
  * Convert a youtu.be or youtube.com URL into a youtube.com/embed/<id> URL.

--- a/client/src/pages/conf/faqs.json
+++ b/client/src/pages/conf/faqs.json
@@ -1,7 +1,7 @@
 [
   {
     "question": "Where can I watch the Azure Cosmos DB Conf stream?",
-    "content": "Watch the live stream right here on <a class='blue' href='#stream'>this page</a> on April 28, 2026, or on the <a class='blue' href='https://youtube.com/live/OdPFriVuKtU' target='_blank' rel='noopener noreferrer'>Microsoft Developer YouTube Channel</a>. All sessions will be available on-demand afterward."
+    "content": "Azure Cosmos DB Conf 2026 streamed live on April 28, 2026. Every session is now available on demand right here on <a class='blue' href='#stream'>this page</a> and on the <a class='blue' href='https://aka.ms/CosmosConf26Playlist' target='_blank' rel='noopener noreferrer'>Microsoft Developer YouTube Channel</a>."
   },
   {
     "question": "Is there a code of conduct for Azure Cosmos DB Conf 2026?",

--- a/client/src/pages/conf/index.tsx
+++ b/client/src/pages/conf/index.tsx
@@ -273,8 +273,8 @@ const ConfPage = () => {
                 from Microsoft and community experts.
               </p>
               <p className={styles.introCopySecondary}>
-                Tune in for our engaging 5-hour live show on <strong>{CONF_DATE_LONG}</strong>, and
-                explore additional sessions on-demand. This is an event you won&apos;t want to miss!
+                Our 5-hour live show streamed on <strong>{CONF_DATE_LONG}</strong>. Every session
+                — keynote, breakouts, and community talks — is now available on demand.
               </p>
             </div>
           </div>

--- a/client/src/pages/conf/sections/AgendaSection.tsx
+++ b/client/src/pages/conf/sections/AgendaSection.tsx
@@ -87,7 +87,7 @@ const AgendaSection = ({ confYear }: AgendaSectionProps) => {
             Event agenda
           </h2>
           <p className={styles.newsDescription}>
-            Join us live on April 28, 2026 from 9:00 AM to 2:00 PM PDT. All times shown in Pacific Daylight Time. Session recordings will be available on demand after the event.
+            Azure Cosmos DB Conf 2026 streamed live on April 28, 2026 from 9:00 AM to 2:00 PM PDT. All times shown in Pacific Daylight Time. Every session is now available on demand.
           </p>
         </div>
 


### PR DESCRIPTION
This pull request updates the conference site to its post-event state now that Azure Cosmos DB Conf 2026 has concluded. The main changes ensure that all sessions are available on demand, remove time-based gating for video access, and update event messaging throughout the site to reflect that the event has ended.

**Post-event behavior and messaging updates:**

* The `useVideoReleased` and `useStreamReleased` hooks in `videoRelease.ts` now always return `true`, permanently enabling video and stream access and suspending all time-based gating logic.
* All event messaging in the FAQ, main intro, and agenda sections has been updated to indicate the live event has concluded and that all sessions are now available on demand. [[1]](diffhunk://#diff-b2c7c4a9f225b9cf8729acb9943eec6778b557185937eaae2933843f6a3d8672L4-R4) [[2]](diffhunk://#diff-cf64a3c58f105fbff60cda12ccf58887ace9fb0292dab39ef8bd916708296884L276-R277) [[3]](diffhunk://#diff-f5d2941214c6be1b461b999df20bc9baccd9a2b01bf8c7c66fce6dacc6542c29L90-R90)

**Code cleanup:**

* Removed unused imports and legacy time-gating logic from `videoRelease.ts`, keeping timestamp constants and helpers in case future events require re-enabling gating. [[1]](diffhunk://#diff-0c914943079e9a47b6af58aa02b79f581035ea115c548cfd2b864b5856306257L1) [[2]](diffhunk://#diff-0c914943079e9a47b6af58aa02b79f581035ea115c548cfd2b864b5856306257L58-R65)